### PR TITLE
Add 74HC132 subcircuit 4 nand with Schmitt Trigger inputs

### DIFF
--- a/resources/data/ic74/74HC132.package
+++ b/resources/data/ic74/74HC132.package
@@ -1,0 +1,40 @@
+<!DOCTYPE SimulIDE>
+
+<!-- *************************************************************************** -->
+<!-- *   Copyright (C) 2017 by santiago González                               * -->
+<!-- *   santigoro@gmail.com                                                   * -->
+<!-- *                                                                         * -->
+<!-- *   This program is free software; you can redistribute it and/or modify  * -->
+<!-- *   it under the terms of the GNU General Public License as published by  * -->
+<!-- *   the Free Software Foundation; either version 3 of the License, or     * -->
+<!-- *   (at your option) any later version.                                   * -->
+<!-- *                                                                         * -->
+<!-- *   This program is distributed in the hope that it will be useful,       * -->
+<!-- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        * -->
+<!-- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         * -->
+<!-- *   GNU General Public License for more details.                          * -->
+<!-- *                                                                         * -->
+<!-- *   You should have received a copy of the GNU General Public License     * -->
+<!-- *   along with this program; if not, see <http://www.gnu.org/licenses/>.  * -->
+<!-- *                                                                         * -->
+<!-- *************************************************************************** -->
+
+<package name="74HC00" pins="14" width="4" height="8" >
+
+    <pin side="left" pos="1"  type="" id="1A"  label="1A" /><!-- packagePin1 -->
+    <pin side="left" pos="2"  type="" id="1B"  label="1B" /><!-- packagePin2 -->
+    <pin side="left" pos="3"  type="" id="1Y"  label="1Y" /><!-- packagePin3 -->
+    <pin side="left" pos="4"  type="" id="2A"  label="2A" /><!-- packagePin4 -->
+    <pin side="left" pos="5"  type="" id="2B"  label="2B" /><!-- packagePin5 -->
+    <pin side="left" pos="6"  type="" id="2Y"  label="2Y" /><!-- packagePin6 -->
+    <pin side="left" pos="7"  type="unused" id="GND" label="GND"/><!-- packagePin7 -->
+
+    <pin side="right" pos="7" type="" id="3Y"  label="3Y" /><!-- packagePin8 -->
+    <pin side="right" pos="6" type="" id="3A"  label="3A" /><!-- packagePin9 -->
+    <pin side="right" pos="5" type="" id="3B"  label="3B" /><!-- packagePin10 -->
+    <pin side="right" pos="4" type="" id="4Y"  label="4Y" /><!-- packagePin11 -->
+    <pin side="right" pos="3" type="" id="4A"  label="4A" /><!-- packagePin12 -->
+    <pin side="right" pos="2" type="" id="4B"  label="4B" /><!-- packagePin13 -->
+    <pin side="right" pos="1" type="unused" id="Vcc" label="Vcc"/><!-- packagePin14 -->
+   
+</package>

--- a/resources/data/ic74/74HC132.subcircuit
+++ b/resources/data/ic74/74HC132.subcircuit
@@ -1,0 +1,87 @@
+<!DOCTYPE SimulIDE>
+
+<!-- *************************************************************************** -->
+<!-- *   Copyright (C) 2017 by santiago González                               * -->
+<!-- *   santigoro@gmail.com                                                   * -->
+<!-- *                                                                         * -->
+<!-- *   This program is free software; you can redistribute it and/or modify  * -->
+<!-- *   it under the terms of the GNU General Public License as published by  * -->
+<!-- *   the Free Software Foundation; either version 3 of the License, or     * -->
+<!-- *   (at your option) any later version.                                   * -->
+<!-- *                                                                         * -->
+<!-- *   This program is distributed in the hope that it will be useful,       * -->
+<!-- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        * -->
+<!-- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         * -->
+<!-- *   GNU General Public License for more details.                          * -->
+<!-- *                                                                         * -->
+<!-- *   You should have received a copy of the GNU General Public License     * -->
+<!-- *   along with this program; if not, see <http://www.gnu.org/licenses/>.  * -->
+<!-- *                                                                         * -->
+<!-- *  Marc HUfschmitt 2020/10/25 : schmitt trigger is hysteresis 1.5 < 3.3V  * -->
+<!-- *      for input High and Low Voltage instead of 2.5 < 2.5                * -->
+<!-- *************************************************************************** -->
+
+
+<subcircuit enodes="0">
+
+    <item itemtype="eAndGate"
+        inputHighV = "3.3"
+        inputLowV = "1.5"
+        inputImped = "100000000000000"
+        outHighV = "5"
+        outLowV = "0"
+        outImped = "40"
+        inverted = "true"
+        numInputs = "2"
+        connections="
+        input0-Package_1A
+        input1-Package_1B
+        output0-Package_1Y" >
+    </item>
+
+    <item itemtype="eAndGate"
+        inputHighV = "3.3"
+        inputLowV = "1.5"
+        inputImped = "100000000000000"
+        outHighV = "5"
+        outLowV = "0"
+        outImped = "40"
+        inverted = "true"
+        numInputs = "2"
+        connections="
+        input0-Package_2A
+        input1-Package_2B
+        output0-Package_2Y" >
+    </item>
+
+    <item itemtype="eAndGate"
+        inputHighV = "3.3"
+        inputLowV = "1.5"
+        inputImped = "100000000000000"
+        outHighV = "5"
+        outLowV = "0"
+        outImped = "40"
+        inverted = "true"
+        numInputs = "2"
+        connections="
+        input0-Package_3A
+        input1-Package_3B
+        output0-Package_3Y" >
+    </item>
+
+    <item itemtype="eAndGate"
+        inputHighV = "3.3"
+        inputLowV = "1.5"
+        inputImped = "100000000000000"
+        outHighV = "5"
+        outLowV = "0"
+        outImped = "40"
+        inverted = "true"
+        numInputs = "2"
+        connections="
+        input0-Package_4A
+        input1-Package_4B
+        output0-Package_4Y" >
+    </item>
+
+</subcircuit>


### PR DESCRIPTION
This is a simple 1st contribution to ic74 library , copying 74HC00 package and subcircuit with 1.5 LowV and 3.3 HighV input instead of 2.5V and 2.5V
and add  simulide/resources/data/ic74.xml :
`<item name="74HC132" package="ic74/74HC132" subcircuit="ic74/74HC132" info="  quad 2-input NAND gate with schmitt trigger" ></item>`